### PR TITLE
Use Code.string_to_quoted!1

### DIFF
--- a/lib/meandro/meandro.ex
+++ b/lib/meandro/meandro.ex
@@ -28,7 +28,7 @@ defmodule Meandro do
     Enum.map(paths, fn p ->
       f = File.open!(p)
       c = IO.read(f, :all)
-      ast = Code.string_to_quoted(c)
+      ast = Code.string_to_quoted!(c)
       {p, ast}
     end)
   end
@@ -37,7 +37,7 @@ defmodule Meandro do
     fun = fn p ->
       f = File.open!(p)
       c = IO.read(f, :all)
-      ast = Code.string_to_quoted(c)
+      ast = Code.string_to_quoted!(c)
       {p, ast}
     end
 


### PR DESCRIPTION
`Code.string_to_quoted/1` returns either `{:ok, Macro.t()` or `{:error, {location :: keyword(), term(), term()}}`. Given that we asume that files exist, and most possibly files are well-formed, let's use instead `Code.string_to_quoted!/1`, which will raise an exception if it errors.