### PR TITLE
Fix parsing of unused callbacks rule with zero args and count callback usage whilst traversing AST

### DIFF
--- a/lib/meandro/rules/unused_callbacks.ex
+++ b/lib/meandro/rules/unused_callbacks.ex
@@ -51,9 +51,14 @@ defmodule Meandro.Rule.UnusedCallbacks do
   defp collect_callbacks(other, acc), do: {other, acc}
 
   defp parse({:callback, meta, [{:"::", _, [definition, _result]}]}) do
-    line = Keyword.get(meta, :line, 0)
-    {name, _, params} = definition
-    {name, length(params), line}
+    line = meta[:line]
+    {name, _meta, params} = definition
+
+    unless is_nil(params) do
+      {name, length(params), line}
+    else
+      {name, 0, line}
+    end
   end
 
   defp is_unused?(name, arity, ast) do

--- a/lib/meandro/rules/unused_callbacks.ex
+++ b/lib/meandro/rules/unused_callbacks.ex
@@ -51,7 +51,7 @@ defmodule Meandro.Rule.UnusedCallbacks do
          {:defmodule, [line: _], [{:__aliases__, [line: _], aliases}, _other]} = ast,
          acc
        ) do
-    module_name = aliases |> Enum.map(&Atom.to_string/1) |> Enum.join(".") |> String.to_atom()
+    module_name = aliases |> Enum.map_join(".", &Atom.to_string/1) |> String.to_atom()
 
     {ast, %{acc | current_module: module_name}}
   end
@@ -101,10 +101,10 @@ defmodule Meandro.Rule.UnusedCallbacks do
     line = meta[:line]
     {name, _meta, params} = definition
 
-    unless is_nil(params) do
-      {name, length(params), line}
-    else
+    if is_nil(params) do
       {name, 0, line}
+    else
+      {name, length(params), line}
     end
   end
 end

--- a/lib/meandro/rules/unused_callbacks.ex
+++ b/lib/meandro/rules/unused_callbacks.ex
@@ -33,22 +33,69 @@ defmodule Meandro.Rule.UnusedCallbacks do
   end
 
   defp analyze_file(file, ast) do
-    {_, callbacks} = Macro.prewalk(ast, [], &collect_callbacks/2)
+    {_, acc} = Macro.prewalk(ast, %{current_module: nil, callbacks: []}, &collect_callbacks/2)
+    %{callbacks: callbacks} = acc
 
-    for {name, arity, line} <- callbacks, is_unused?(name, arity, ast) do
+    for {module, name, arity, line, count} <- callbacks, count == 0 do
       %Meandro.Rule{
         file: file,
         line: line,
-        text: "Callback #{name}/#{arity} is not used anywhere in the module",
+        text: "Callback #{module}:#{name}/#{arity} is not used anywhere in the module",
         pattern: {name, arity}
       }
     end
   end
 
-  defp collect_callbacks({:callback, _, _} = callback, acc),
-    do: {callback, [parse(callback) | acc]}
+  # When we find a module definition we write it down, so we can pair it with the callback definition
+  defp collect_callbacks(
+         {:defmodule, [line: _], [{:__aliases__, [line: _], aliases}, _other]} = ast,
+         acc
+       ) do
+    module_name = aliases |> Enum.map(&Atom.to_string/1) |> Enum.join(".") |> String.to_atom()
+
+    {ast, %{acc | current_module: module_name}}
+  end
+
+  # When we find a callback, we write it down together with the module it was found on.
+  # We also count the number of times a module:callback/arity has been found whilst traversing
+  # the AST.
+  defp collect_callbacks(
+         {:callback, _, _} = callback,
+         %{current_module: module, callbacks: callbacks} = acc
+       ) do
+    {name, arity, line} = parse(callback)
+
+    {callback, %{acc | callbacks: [{module, name, arity, line, 0} | callbacks]}}
+  end
+
+  # Standard function application: SOMETHING.name(params) with the right number of params
+  defp collect_callbacks({{:., _, [_, name]}, _, params} = node, acc) do
+    {node, maybe_update_callback_count(acc, name, _arity = length(params))}
+  end
+
+  # Function references: &SOMETHING.name/arity
+  defp collect_callbacks(
+         {:&, _, [{:/, _, [{{:., _, [_, name]}, _, []}, arity]}]} = node,
+         acc
+       ) do
+    {node, maybe_update_callback_count(acc, name, arity)}
+  end
 
   defp collect_callbacks(other, acc), do: {other, acc}
+
+  defp maybe_update_callback_count(
+         %{callbacks: callbacks, current_module: module} = acc,
+         name,
+         arity
+       ) do
+    callbacks =
+      Enum.map(callbacks, fn
+        {^module, ^name, ^arity, line, count} -> {module, name, arity, line, count + 1}
+        e -> e
+      end)
+
+    %{acc | callbacks: callbacks}
+  end
 
   defp parse({:callback, meta, [{:"::", _, [definition, _result]}]}) do
     line = meta[:line]
@@ -60,26 +107,4 @@ defmodule Meandro.Rule.UnusedCallbacks do
       {name, 0, line}
     end
   end
-
-  defp is_unused?(name, arity, ast) do
-    {_, count} = Macro.prewalk(ast, 0, fn node, acc -> count_calls(name, arity, node, acc) end)
-    count == 0
-  end
-
-  # Standard function application: SOMETHING.name(params) with the right number of params
-  defp count_calls(name, arity, {{:., _, [_, name]}, _, params} = node, acc)
-       when length(params) == arity,
-       do: {node, acc + 1}
-
-  # Function references: &SOMETHING.name/arity
-  defp count_calls(
-         name,
-         arity,
-         {:&, _, [{:/, _, [{{:., _, [_, name]}, _, []}, arity]}]} = node,
-         acc
-       ),
-       do: {node, acc + 1}
-
-  # All other nodes
-  defp count_calls(_, _, node, acc), do: {node, acc}
 end

--- a/lib/mix/meandro.ex
+++ b/lib/mix/meandro.ex
@@ -28,6 +28,9 @@ defmodule Mix.Tasks.Meandro do
   """
   use Mix.Task
 
+  # @rules should have the following format
+  # [{:unused_callbacks, Meandro.Rule.UnusedCallbacks},
+  #  {:unused_struct_fields, Meandro.Rule.UnusedStructFields},...]
   @rules []
 
   # runs the task recursively in umbrella projects
@@ -47,11 +50,11 @@ defmodule Mix.Tasks.Meandro do
 
     Mix.shell().info("Looking for oxbow lakes to dry up...")
     # TODO get all the rules dynamically
-    rules = @rules
+    rules = for {_rule, rule_mod} <- @rules, do: rule_mod
     Mix.shell().info("Meandro rules: #{inspect(rules)}")
 
     ## All files except those under _build or _checkouts
-    files = get_files(Keyword.get(parsed, :files), rest)
+    files = get_files(parsed[:files], rest)
 
     parsing_style =
       Keyword.get(parsed, :parsing, "parallel")


### PR DESCRIPTION
Fixes #22, by instead of considering callbacks a tuple of `{name, arity, line}` a tuple of `{module, name, arity, line}`

I took the chance to refactor the code in `lib/meandro/rules/unused_callbacks.ex` to count the usage of the callbacks whilst traversing the AST for the first time, instead of traversing it once to get the list of callbacks, and then traversing it again for each of the callbacks we found.