### PR TITLE
#6: Unnecessary Function Arguments Rule

### DIFF
--- a/lib/meandro/rules/unnecessary_function_arguments.ex
+++ b/lib/meandro/rules/unnecessary_function_arguments.ex
@@ -26,7 +26,7 @@ defmodule Meandro.Rule.UnnecessaryFunctionArguments do
     true
   end
 
-  def is_ignored?({function, arity, position}, function) do
+  def is_ignored?({function, _arity, _position}, function) do
     false
   end
 
@@ -35,6 +35,100 @@ defmodule Meandro.Rule.UnnecessaryFunctionArguments do
   end
 
   defp analyze_file(file, ast) do
-    []
+    {_, acc} = Macro.prewalk(ast, %{current_module: nil, functions: %{}}, &collect_functions/2)
+    %{functions: functions} = acc
+
+    for {module, function, arity, position, line} <- unnecessary_arguments(functions) do
+      %Meandro.Rule{
+        file: file,
+        line: line,
+        text:
+          "Argument in position #{position} of #{module}.#{function}/#{arity} is ignored in all of its clauses",
+        pattern: {function, arity, position}
+      }
+    end
   end
+
+  # When we find a module definition we write it down, so we can pair it with the callback definition
+  defp collect_functions(
+         {:defmodule, [line: _], [{:__aliases__, [line: _], aliases}, _other]} = ast,
+         acc
+       ) do
+    module_name = aliases |> Enum.map_join(".", &Atom.to_string/1) |> String.to_atom()
+
+    {ast, %{acc | current_module: module_name}}
+  end
+
+  defp collect_functions({def, meta, [params | _]} = node, acc)
+       when params != nil and (def == :def or def == :defp) do
+    {name, _meta, arguments} =
+      case params do
+        {:when, _, [actual_params | _]} ->
+          actual_params
+
+        params ->
+          params
+      end
+
+    %{current_module: module, functions: functions} = acc
+
+    arg_patterns = extract_arg_patterns(arguments)
+    key = {module, name, length(arg_patterns)}
+    clause = {meta[:line], arg_patterns}
+
+    new_functions =
+      Map.update(
+        functions,
+        key,
+        [clause],
+        &[clause | &1]
+      )
+
+    {node, %{acc | functions: new_functions}}
+  end
+
+  defp collect_functions(node, acc) do
+    {node, acc}
+  end
+
+  defp extract_arg_patterns(nil), do: []
+
+  defp extract_arg_patterns(arguments) do
+    for arg <- arguments do
+      case arg do
+        {pattern, _, _} -> pattern
+        _other -> :a_pattern
+      end
+    end
+  end
+
+  defp unnecessary_arguments(functions) do
+    for {{module, function, arity}, clauses} <- functions,
+        {line, position} <- unnecessary_arguments(arity, clauses) do
+      {module, function, arity, position, line}
+    end
+  end
+
+  defp unnecessary_arguments(arity, clauses) do
+    # It's actually the first one since we constructed this list using cons on a prewalk
+    {line, _} = List.last(clauses)
+    for position <- 1..arity, is_ignored_in_all_clauses?(position, clauses), do: {line, position}
+  end
+
+  defp is_ignored_in_all_clauses?(position, clauses) do
+    Enum.all?(clauses, fn {_, arg_patterns} ->
+      Enum.at(arg_patterns, position - 1) |> is_ignored?
+    end)
+  end
+
+  defp is_ignored?(:_), do: true
+
+  defp is_ignored?(atom) when is_atom(atom) do
+    case Atom.to_string(atom) do
+      "_" <> _ -> true
+      _ -> false
+    end
+  end
+
+  defp is_ignored(_), do: false
 end

--- a/lib/meandro/rules/unnecessary_function_arguments.ex
+++ b/lib/meandro/rules/unnecessary_function_arguments.ex
@@ -1,0 +1,40 @@
+defmodule Meandro.Rule.UnnecessaryFunctionArguments do
+  @moduledoc """
+  Finds function arguments that are consistently ignored in all clauses of a function.
+
+  This rule assumes that:
+  1. You don't use variables starting with `_` (i.e. you always ignore those).
+  2. You tag all the methods that implement behaviour callbacks with @impl
+  """
+
+  @behaviour Meandro.Rule
+
+  @impl Meandro.Rule
+  def analyze(files_and_asts, _options) do
+    for {file, ast} <- files_and_asts,
+        result <- analyze_file(file, ast) do
+      result
+    end
+  end
+
+  @impl Meandro.Rule
+  def is_ignored?({function, arity, position}, {function, arity, position}) do
+    true
+  end
+
+  def is_ignored?({function, arity, _position}, {function, arity}) do
+    true
+  end
+
+  def is_ignored?({function, arity, position}, function) do
+    false
+  end
+
+  def is_ignored?(_pattern, _ignore_spec) do
+    false
+  end
+
+  defp analyze_file(file, ast) do
+    []
+  end
+end

--- a/test/rules/unnecessary_function_arguments/bad.exs
+++ b/test/rules/unnecessary_function_arguments/bad.exs
@@ -14,8 +14,8 @@ defmodule MeandroTest.UFA.Bad do
   def also_ignore(_, _), do: "All arguments ignored in this clause"
 
   @doc "Private function"
-  defp private(:function, _with, _two, :args, :ignored) do
-    {2, :args, :are, :ignored}
+  defp private("function", _with, _two, :args, {:ignored, ignored}) do
+    {2, :args, :are, ignored}
   end
 
   defp private(:second_clause, _with, _more, _ignored, _args) do

--- a/test/rules/unnecessary_function_arguments/bad.exs
+++ b/test/rules/unnecessary_function_arguments/bad.exs
@@ -1,0 +1,24 @@
+@doc "Some arguments are unused"
+defmodule MeandroTest.UFA.Bad do
+  @doc "One argument, one clause"
+  def ignore(_this_argument), do: :ignored
+
+  @doc "Two arguments, one clause, one arg is ignored"
+  def ignore(the_second, _argument), do: {the_second, :is, :ignored}
+
+  @doc "Two arguments, two clauses, one arg is ignored"
+  def also_ignore(the_second, _argument) when is_atom(the_second) do
+    {the_second, :argument, :is, :ignored}
+  end
+
+  def also_ignore(_, _), do: "All arguments ignored in this clause"
+
+  @doc "Private function"
+  defp private(:function, _with, _two, :args, :ignored) do
+    {2, :args, :are, :ignored}
+  end
+
+  defp private(:second_clause, _with, _more, _ignored, _args) do
+    {4, :args, :are, :ignored}
+  end
+end

--- a/test/rules/unnecessary_function_arguments/good.exs
+++ b/test/rules/unnecessary_function_arguments/good.exs
@@ -1,0 +1,21 @@
+@doc "all function arguments are necessary here"
+defmodule MeandroTest.UFA.Good do
+  @doc "One argument, one clause"
+  def one_one(arg1), do: arg1
+
+  @doc "Two arguments, one clause"
+  def two_one(arg1, arg2) do
+    arg1 + arg2
+  end
+
+  @doc "One argument, two clauses"
+  def one_two(arg1) when is_binary(arg1), do: "Arg1 is " <> arg1
+  def one_two(_) when is_binary(arg2), do: "Arg1 is ignored"
+
+  @doc "Two arguments, two clauses"
+  defp two_two(arg1, arg2) when is_binary(arg2), do: "Arg2 is only used in guards " <> arg1
+
+  defp two_two(arg1, arg2) when is_binary(arg1), is_atom(arg2) do
+    "All args only used in guards"
+  end
+end

--- a/test/rules/unnecessary_function_arguments/good.exs
+++ b/test/rules/unnecessary_function_arguments/good.exs
@@ -18,7 +18,7 @@ defmodule MeandroTest.UFA.Good do
   defp two_two(arg1, arg2) when is_binary(arg1), is_atom(arg2) do
     "All args only used in guards"
   end
-  
+
   defp with_integer(0), do: "argument is an integer"
   defp with_string("boo"), do: "argument is a string"
 end

--- a/test/rules/unnecessary_function_arguments/good.exs
+++ b/test/rules/unnecessary_function_arguments/good.exs
@@ -18,4 +18,7 @@ defmodule MeandroTest.UFA.Good do
   defp two_two(arg1, arg2) when is_binary(arg1), is_atom(arg2) do
     "All args only used in guards"
   end
+  
+  defp with_integer(0), do: "argument is an integer"
+  defp with_string("boo"), do: "argument is a string"
 end

--- a/test/rules/unnecessary_function_arguments/none.exs
+++ b/test/rules/unnecessary_function_arguments/none.exs
@@ -1,0 +1,12 @@
+@doc "There are no function arguments here here"
+defmodule MeandroTest.UFA.None do
+  @doc "A regular function with no arguments"
+  def public do
+    :no_args
+  end
+
+  @doc "A private function with no arguments"
+  defp private do
+    :no_args
+  end
+end

--- a/test/rules/unnecessary_function_arguments/unnecessary_function_arguments.exs
+++ b/test/rules/unnecessary_function_arguments/unnecessary_function_arguments.exs
@@ -1,0 +1,62 @@
+defmodule MeandroTest.Rule.UnnecessaryFunctionArguments do
+  use ExUnit.Case
+
+  alias Meandro.Rule
+  alias Meandro.Rule.UnnecessaryFunctionArguments
+
+  @test_directory_path "test/rules/unnecessary_function_arguments/"
+
+  test "emits no warnings on files without function arguments" do
+    files_and_asts = parse_files(["none.exs"])
+    assert [] = Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext)
+  end
+
+  test "emits no warnings on files where all function arguments are used" do
+    files_and_asts = parse_files(["good.exs"])
+    assert [] = Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext)
+  end
+
+  test "emits warnings on files where a function argument is unused" do
+    file = "bad.exs"
+    module = read_module_name(file)
+
+    expected_warnings = [
+      {4, :ignore, 1, 1},
+      {7, :ignore, 2, 2},
+      {10, :also_ignore, 2, 2},
+      {17, :private, 5, 2},
+      {17, :private, 5, 3}
+    ]
+
+    expected_results =
+      for {line, function, arity, position} <- expected_warnings do
+        %Meandro.Rule{
+          file: @test_directory_path <> "bad.exs",
+          line: line,
+          pattern: {function, arity, position},
+          rule: Meandro.Rule.UnnecessaryFunctionArguments,
+          text:
+            "Argument in position #{position} of #{module}.#{function}/#{arity} is ignored in all of its clauses"
+        }
+      end
+
+    files_and_asts = parse_files([file])
+
+    assert expected_results =
+             Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext)
+  end
+
+  defp parse_files(paths) do
+    files = for p <- paths, do: @test_directory_path <> p
+    Meandro.Util.parse_files(files, :sequential)
+  end
+
+  defp read_module_name(file_path) do
+    {:ok, contents} = File.read(@test_directory_path <> file_path)
+    pattern = ~r{defmodule \s+ ([^\s]+) }x
+
+    Regex.scan(pattern, contents, capture: :all_but_first)
+    |> List.flatten()
+    |> List.first()
+  end
+end

--- a/test/rules/unnecessary_function_arguments/unnecessary_function_arguments_test.exs
+++ b/test/rules/unnecessary_function_arguments/unnecessary_function_arguments_test.exs
@@ -42,7 +42,7 @@ defmodule MeandroTest.Rule.UnnecessaryFunctionArguments do
 
     files_and_asts = parse_files([file])
 
-    assert expected_results =
+    assert ^expected_results =
              Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext)
   end
 

--- a/test/rules/unnecessary_function_arguments/unnecessary_function_arguments_test.exs
+++ b/test/rules/unnecessary_function_arguments/unnecessary_function_arguments_test.exs
@@ -43,7 +43,7 @@ defmodule MeandroTest.Rule.UnnecessaryFunctionArguments do
     files_and_asts = parse_files([file])
 
     assert ^expected_results =
-             Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext)
+             Enum.sort(Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext))
   end
 
   defp parse_files(paths) do


### PR DESCRIPTION
Initial work on #6: Unnecessary Function Arguments Rule.

This is the naïve implementation of the rule. The ticket should not be closed since there are many more things to consider, like checking for `@impl …` to skip behaviour callbacks… and other stuff.