### PR TITLE
Enable several Credo rules

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -22,14 +22,8 @@
         # In the latter case `**/*.{ex,exs}` will be used.
         #
         included: [
-          "lib/",
-          "src/",
-          "test/",
-          "web/",
-          "apps/*/lib/",
-          "apps/*/src/",
-          "apps/*/test/",
-          "apps/*/web/"
+          "lib/**",
+          "test/**"
         ],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
@@ -156,18 +150,15 @@
           {Credo.Check.Warning.UnusedRegexOperation, []},
           {Credo.Check.Warning.UnusedStringOperation, []},
           {Credo.Check.Warning.UnusedTupleOperation, []},
-          {Credo.Check.Warning.UnsafeExec, []}
-        ],
-        disabled: [
-          #
-          # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+          {Credo.Check.Warning.UnsafeExec, []},
+
+          # TODO [#14]: Enable this rule
+          # {Credo.Check.Readability.Specs, []},
 
           #
-          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
-          #   and be sure to use `mix credo --strict` to see low priority checks)
+          ## Controversial and experimental checks
           #
           {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
-          {Credo.Check.Consistency.UnusedVariableNames, []},
           {Credo.Check.Design.DuplicatedCode, []},
           {Credo.Check.Design.SkipTestWithoutComment, []},
           {Credo.Check.Readability.AliasAs, []},
@@ -177,17 +168,12 @@
           {Credo.Check.Readability.NestedFunctionCalls, []},
           {Credo.Check.Readability.SeparateAliasRequire, []},
           {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
-          {Credo.Check.Readability.SinglePipe, []},
-          {Credo.Check.Readability.Specs, []},
           {Credo.Check.Readability.StrictModuleLayout, []},
           {Credo.Check.Readability.WithCustomTaggedTuple, []},
-          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.ABCSize, [max_size: 50]},
           {Credo.Check.Refactor.AppendSingleItem, []},
           {Credo.Check.Refactor.DoubleBooleanNegation, []},
           {Credo.Check.Refactor.FilterReject, []},
-          {Credo.Check.Refactor.IoPuts, []},
-          {Credo.Check.Refactor.MapMap, []},
-          {Credo.Check.Refactor.ModuleDependencies, []},
           {Credo.Check.Refactor.NegatedIsNil, []},
           {Credo.Check.Refactor.PipeChainStart, []},
           {Credo.Check.Refactor.RejectFilter, []},
@@ -195,14 +181,19 @@
           {Credo.Check.Warning.LazyLogging, []},
           {Credo.Check.Warning.LeakyEnvironment, []},
           {Credo.Check.Warning.MapGetUnsafePass, []},
-          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.MixEnv, []}
+        ],
+        disabled: [
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
           {Credo.Check.Warning.UnsafeToAtom, []}
-
-          # {Credo.Check.Refactor.MapInto, []},
-
-          #
-          # Custom checks can be created using `mix credo.gen.check`.
-          #
         ]
       }
     }

--- a/lib/meandro/rules/unnecessary_function_arguments.ex
+++ b/lib/meandro/rules/unnecessary_function_arguments.ex
@@ -120,7 +120,7 @@ defmodule Meandro.Rule.UnnecessaryFunctionArguments do
 
   defp is_ignored_in_all_clauses?(position, clauses) do
     Enum.all?(clauses, fn {_, arg_patterns} ->
-      Enum.at(arg_patterns, position - 1) |> is_ignored?
+      arg_patterns |> Enum.at(position - 1) |> is_ignored?
     end)
   end
 

--- a/lib/meandro/rules/unused_callbacks.ex
+++ b/lib/meandro/rules/unused_callbacks.ex
@@ -9,9 +9,9 @@ defmodule Meandro.Rule.UnusedCallbacks do
      If you use `apply(…)` or other method, you'll have to ignore this rule.
   """
 
-  alias Meandro.Util
-
   @behaviour Meandro.Rule
+
+  alias Meandro.Util
 
   @impl Meandro.Rule
   def analyze(files_and_asts, _options) do

--- a/lib/meandro/rules/unused_macros.ex
+++ b/lib/meandro/rules/unused_macros.ex
@@ -12,7 +12,6 @@ defmodule Meandro.Rule.UnusedMacros do
         result <- analyze_module(file, ast, files_and_asts) do
       result
     end
-    |> List.flatten()
   end
 
   @impl Meandro.Rule
@@ -32,23 +31,17 @@ defmodule Meandro.Rule.UnusedMacros do
     module_aliases = Meandro.Util.module_aliases(ast)
     macros = macros(ast, module_aliases)
 
-    for macro_info <- macros do
-      unused = is_unused?(macro_info, files_and_asts)
-      macro = macro_info |> Map.get(:name)
-      line = macro_info |> Map.get(:line)
-      arity = macro_info |> Map.get(:arity)
+    for macro_info <- macros,
+        is_unused?(macro_info, files_and_asts) do
+      %{name: macro, line: line, arity: arity} = macro_info
 
-      if unused do
-        %Meandro.Rule{
-          file: file,
-          rule: __MODULE__,
-          line: line,
-          pattern: {macro, arity},
-          text: "The macro #{macro}/#{arity} is unused"
-        }
-      else
-        []
-      end
+      %Meandro.Rule{
+        file: file,
+        rule: __MODULE__,
+        line: line,
+        pattern: {macro, arity},
+        text: "The macro #{macro}/#{arity} is unused"
+      }
     end
   end
 
@@ -58,9 +51,7 @@ defmodule Meandro.Rule.UnusedMacros do
 
   defp is_unused?(macro_info, [{_file, ast} | tl]) do
     functions = Meandro.Util.functions(ast)
-    macro = macro_info |> Map.get(:name)
-    aliases = macro_info |> Map.get(:aliases)
-    arity = macro_info |> Map.get(:arity)
+    %{name: macro, aliases: aliases, arity: arity} = macro_info
 
     unused_in_functions =
       for function <- functions do

--- a/lib/meandro/rules/unused_struct_field.ex
+++ b/lib/meandro/rules/unused_struct_field.ex
@@ -7,9 +7,9 @@ defmodule Meandro.Rule.UnusedStructFields do
       struct field or modification
   """
 
-  alias Meandro.Util
-
   @behaviour Meandro.Rule
+
+  alias Meandro.Util
 
   @impl Meandro.Rule
   def analyze(files_and_asts, _options) do
@@ -18,7 +18,6 @@ defmodule Meandro.Rule.UnusedStructFields do
         result <- analyze_module(file, ast, files_and_asts) do
       result
     end
-    |> List.flatten()
   end
 
   @impl Meandro.Rule
@@ -45,20 +44,13 @@ defmodule Meandro.Rule.UnusedStructFields do
         module_name = struct_info[:module_name]
         module_aliases = struct_info[:module_aliases]
 
-        for field <- fields do
-          unused = is_unused?({field, module_name, module_aliases}, files_and_asts)
-
-          case unused do
-            true ->
-              %Meandro.Rule{
-                file: file,
-                pattern: {module_name, field},
-                text: "The field #{field} from the struct #{module_name} is unused"
-              }
-
-            false ->
-              []
-          end
+        for field <- fields,
+            is_unused?({field, module_name, module_aliases}, files_and_asts) do
+          %Meandro.Rule{
+            file: file,
+            pattern: {module_name, field},
+            text: "The field #{field} from the struct #{module_name} is unused"
+          }
         end
     end
   end
@@ -145,8 +137,7 @@ defmodule Meandro.Rule.UnusedStructFields do
   end
 
   defp collect_struct_info({:defstruct, [line: _], [fields]} = ast, struct_info) do
-    struct_info = struct_info |> Map.put_new(:fields, fields)
-    {ast, struct_info}
+    {ast, Map.put_new(struct_info, :fields, fields)}
   end
 
   defp collect_struct_info(other, module_name) do

--- a/lib/meandro/util.ex
+++ b/lib/meandro/util.ex
@@ -37,13 +37,13 @@ defmodule Meandro.Util do
 
   defp maybe_split_by_module(ast, file) do
     {_, {_, result}} = Macro.prewalk(ast, {file, []}, &collect_modules/2)
-    {file, result}
+    {file, Enum.reverse(result)}
   end
 
   defp collect_modules({:defmodule, _, params} = module_node, {file, acc}) do
     case params do
       [{:__aliases__, _, _} | _] ->
-        {module_node, {file, acc ++ [{module_name(module_node), module_node}]}}
+        {module_node, {file, [{module_name(module_node), module_node} | acc]}}
 
       _ ->
         # @todo cry and fix this
@@ -68,7 +68,8 @@ defmodule Meandro.Util do
     {:ok, contents} = File.read(file_path)
     pattern = ~r{defmodule \s+ ([^\s]+) }x
 
-    Regex.scan(pattern, contents, capture: :all_but_first)
+    pattern
+    |> Regex.scan(contents, capture: :all_but_first)
     |> List.flatten()
     |> Module.concat()
   end

--- a/lib/mix/meandro.ex
+++ b/lib/mix/meandro.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Meandro do
   # @todo Add to the @moduledoc information about the rules meandro supports
+  @shortdoc "Identifies dead code for you"
   @moduledoc """
   `meandro` is a helper for dead code cleaning. It can assist you on searching
   for Oxbow code (dead code), and thus on keeping your application clean and tidy.
@@ -31,7 +32,6 @@ defmodule Mix.Tasks.Meandro do
   # runs the task recursively in umbrella projects
   @recursive true
 
-  @shortdoc "Identifies dead code for you"
   @files_wildcard "**/*.{ex,exs}"
   @rules_wildcard "lib/meandro/rules/*.ex"
 
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Meandro do
     parsing: :string
   ]
 
-  @impl true
+  @impl Mix.Task
   def run(argv \\ []) do
     {parsed, rest} = OptionParser.parse!(argv, strict: @switches)
 
@@ -53,7 +53,8 @@ defmodule Mix.Tasks.Meandro do
       |> Path.join()
 
     rule_files =
-      Path.join(meandro_root, @rules_wildcard)
+      meandro_root
+      |> Path.join(@rules_wildcard)
       |> Path.wildcard()
 
     rules =
@@ -66,7 +67,8 @@ defmodule Mix.Tasks.Meandro do
     files = get_files(parsed[:files], rest)
 
     parsing_style =
-      Keyword.get(parsed, :parsing, "parallel")
+      parsed
+      |> Keyword.get(:parsing, "parallel")
       |> String.to_existing_atom()
 
     Mix.shell().info("Meandro will use #{length(files)} files for analysis: #{inspect(files)}")
@@ -83,7 +85,8 @@ defmodule Mix.Tasks.Meandro do
   end
 
   defp get_files(_, _) do
-    Path.wildcard(@files_wildcard)
+    @files_wildcard
+    |> Path.wildcard()
     |> Enum.reject(&is_hidden_name?/1)
   end
 

--- a/test/rules/unnecessary_function_arguments/edges.exs
+++ b/test/rules/unnecessary_function_arguments/edges.exs
@@ -7,8 +7,9 @@ end
 defmodule MeandroTest.UFA.MyImpl do
   @moduledoc "MyBeh implementation"
 
-  alias MeandroTest.UFA.MyBeh
   @behaviour MyBeh
+
+  alias MeandroTest.UFA.MyBeh
 
   @impl MyBeh
   @spec a_callback(any()) :: tuple()

--- a/test/rules/unnecessary_function_arguments/unnecessary_function_arguments_test.exs
+++ b/test/rules/unnecessary_function_arguments/unnecessary_function_arguments_test.exs
@@ -43,7 +43,9 @@ defmodule MeandroTest.Rule.UnnecessaryFunctionArguments do
     files_and_asts = TestHelpers.parse_files([file])
 
     assert ^expected_results =
-             Enum.sort(Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext))
+             UnnecessaryFunctionArguments
+             |> Rule.analyze(files_and_asts, :nocontext)
+             |> Enum.sort()
   end
 
   test "handles exceptions and edge cases correctly" do
@@ -51,8 +53,8 @@ defmodule MeandroTest.Rule.UnnecessaryFunctionArguments do
     module = "MeandroTest.UFA.MyImpl"
 
     expected_warnings = [
-      {17, :another_callback, 1, 1},
-      {22, :warn, 1, 1}
+      {18, :another_callback, 1, 1},
+      {23, :warn, 1, 1}
     ]
 
     expected_results =
@@ -70,6 +72,8 @@ defmodule MeandroTest.Rule.UnnecessaryFunctionArguments do
     files_and_asts = TestHelpers.parse_files([file])
 
     assert ^expected_results =
-             Enum.sort(Rule.analyze(UnnecessaryFunctionArguments, files_and_asts, :nocontext))
+             UnnecessaryFunctionArguments
+             |> Rule.analyze(files_and_asts, :nocontext)
+             |> Enum.sort()
   end
 end

--- a/test/rules/unused_record_fields/unused_record_fields_test.exs
+++ b/test/rules/unused_record_fields/unused_record_fields_test.exs
@@ -159,18 +159,19 @@ defmodule MeandroTest.UnusedRecordField do
     {:ok, contents} = File.read(file_path)
     pattern = ~r{Record\.defrecordp?\([:a-zA-Z](.*)\)}x
 
-    Regex.scan(pattern, contents, capture: :all_but_first)
+    pattern
+    |> Regex.scan(contents, capture: :all_but_first)
     |> List.flatten()
     |> Enum.map(&parse_str_record/1)
   end
 
   defp parse_str_record(str_record) do
-    [record_name | fields] = String.split(str_record, ", ")
-    record_name_camelized = Macro.camelize(record_name) |> String.to_atom()
-    record_name = String.to_atom(record_name)
+    [str_record_name | str_fields] = String.split(str_record, ", ")
+    record_name_camelized = str_record_name |> Macro.camelize() |> String.to_atom()
+    record_name = String.to_atom(str_record_name)
 
     fields =
-      Enum.map(fields, fn str_field ->
+      Enum.map(str_fields, fn str_field ->
         [field_name, _value] = String.split(str_field, ": ")
         String.to_atom(field_name)
       end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,7 +9,8 @@ defmodule TestHelpers do
     {:ok, contents} = File.read(file_path)
     pattern = ~r{defmodule \s+ ([^\s]+) }x
 
-    Regex.scan(pattern, contents, capture: :all_but_first)
+    pattern
+    |> Regex.scan(contents, capture: :all_but_first)
     |> List.flatten()
     |> List.first()
     |> String.to_atom()


### PR DESCRIPTION
Before enabling the rule requiring specs in functions, I found a bunch of other very interesting rules in Credo. I enabled them. 😎 