### PR TITLE
Read config from mix exs file

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -96,7 +96,7 @@
           {Credo.Check.Readability.ModuleDoc, []},
           {Credo.Check.Readability.ModuleNames, []},
           {Credo.Check.Readability.ParenthesesInCondition, []},
-          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, [parens: true]},
           {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
           {Credo.Check.Readability.PredicateFunctionNames, []},
           {Credo.Check.Readability.PreferImplicitTry, []},

--- a/lib/meandro/meandro.ex
+++ b/lib/meandro/meandro.ex
@@ -15,24 +15,54 @@ defmodule Meandro do
   @doc """
   Runs a list of rules over a list of files and returns all the dead code pieces it can find.
   """
-  @spec analyze([Path.t()], [module()], Meandro.Util.parsing_style()) :: result()
-  def analyze(files, rules, parsing_style) do
-    files_and_asts = Meandro.Util.parse_files(files, parsing_style)
+  @spec analyze([Path.t()], [Meandro.Rule.t()], Meandro.Util.parsing_style(), [
+          Meandro.ConfigParser.ignore()
+        ]) :: result()
+  def analyze(files, rules, parsing_style, ignores) do
+    ignores_from_config =
+      for {file, rule_ignored, _opts} <- ignores,
+          rule <- rules,
+          rule_ignored == :all or rule_ignored == rule,
+          do: {file, rule}
 
-    results =
-      Enum.reduce(rules, [], fn rule_mod, acc ->
+    files_ignored_from_config = for {file, :all} <- ignores_from_config, do: file
+    # @todo add @meandro attributes to the final list, before calling usort
+    wholly_ignored_files = :lists.usort(files_ignored_from_config)
+
+    files_and_asts =
+      files
+      |> Enum.reject(fn file -> file in wholly_ignored_files end)
+      |> Meandro.Util.parse_files(parsing_style)
+
+    # @todo add @meandro attributes to the final list
+    all_ignores = ignores_from_config
+
+    {results, ignored_results} =
+      rules
+      |> Enum.reduce([], fn rule_mod, acc ->
         Meandro.Rule.analyze(rule_mod, files_and_asts, :nocontext) ++ acc
       end)
+      |> remove_ignored_results(all_ignores)
 
     %{
       results: results,
       unused_ignores: [],
       stats: %{
-        ignored: 0,
+        ignored: length(ignored_results),
         parsed: length(files_and_asts),
         analyzed: length(files_and_asts),
         total: length(files_and_asts)
       }
     }
+  end
+
+  defp remove_ignored_results(results, ignores),
+    do: remove_ignored_results(results, ignores, {[], []})
+
+  defp remove_ignored_results([], _ignores, {filtered_results, ignored_results}),
+    do: {Enum.reverse(filtered_results), ignored_results}
+
+  defp remove_ignored_results([result | results], ignores, {filtered_results, ignored_results}) do
+    remove_ignored_results(results, ignores, {[result | filtered_results], ignored_results})
   end
 end

--- a/lib/meandro/meandro_config_parser.ex
+++ b/lib/meandro/meandro_config_parser.ex
@@ -1,0 +1,119 @@
+defmodule Meandro.ConfigParser do
+  @moduledoc """
+  Meandro's `mix.exs` configuration parser (note: it parses, but doesn't validate the data).
+
+  Given a config file (the file defaults to `mix.exs`), this module will try to parse out of
+  it the set of rules to analyze with, the parsing style, and the list of ignores.
+
+  More information about these configuration parameters can be found in the README.md
+  """
+
+  @typedoc """
+  Meandro's final result.
+  """
+
+  @rules_wildcard "lib/meandro/rules/*.ex"
+
+  @type ignore :: {Path.t(), Meandro.Rule.t(), list()}
+  @type meandro_config() :: [
+          rules: [Meandro.Rule.t()],
+          parsing: Meandro.Util.parsing_style(),
+          ignore: [ignore()]
+        ]
+
+  @spec parse_config() :: meandro_config()
+  def parse_config(), do: parse_config(Mix.Project.config())
+
+  @spec parse_config(keyword()) :: meandro_config()
+  def parse_config(config) do
+    meandro_config = config[:meandro] || []
+
+    [
+      rules: get_rules(meandro_config[:rules]),
+      parsing: get_parsing_style(meandro_config[:parsing]),
+      ignore: get_ignores(meandro_config[:ignore])
+    ]
+  end
+
+  @spec get_rules([Meandro.Rule.t() | nil]) :: [Meandro.Rule.t()]
+  defp get_rules(nil), do: default_rules()
+
+  defp get_rules(rules) do
+    rule_files()
+    |> Enum.filter(fn file ->
+      rule =
+        file
+        |> Path.basename(".ex")
+        |> String.to_atom()
+
+      rule in rules
+    end)
+    |> Enum.map(&Meandro.Util.module_name_from_file_path/1)
+  end
+
+  @spec get_parsing_style(Meandro.Util.parsing_style() | nil) :: Meandro.Util.parsing_style()
+  defp get_parsing_style(nil), do: :parallel
+  defp get_parsing_style(style), do: style
+
+  defp get_ignores(nil), do: []
+
+  @spec get_ignores([
+          Path.t()
+          | {Path.t(), Meandro.Rule.t() | [Meandro.Rule.t()]}
+          | {Path.t(), Meandro.Rule.t() | [Meandro.Rule.t()], list()}
+        ]) :: [ignore()]
+  defp get_ignores(ignores) do
+    for {wildcard, rule, opts} <- normalize_ignores(ignores),
+        file <- expand_wildcard(wildcard),
+        do: {file, rule, opts}
+  end
+
+  # someone used the [keyword: value] when defining the ignore list,
+  # which turned the file path into an atom
+  defp expand_wildcard(wildcard) when is_atom(wildcard) do
+    wildcard
+    |> Atom.to_string()
+    |> Path.wildcard()
+  end
+
+  defp expand_wildcard(wildcard), do: Path.wildcard(wildcard)
+
+  defp normalize_ignores(ignores) do
+    Enum.reduce(ignores, [], &normalize_ignores/2)
+  end
+
+  defp normalize_ignores(ignore, acc) when is_tuple(ignore),
+    do: normalize_ignore_tuple(ignore, acc)
+
+  # @todo update when we add opts to the ignore ruleset
+  defp normalize_ignores(ignore, acc), do: [{ignore, :all, []} | acc]
+
+  defp normalize_ignore_tuple({wildcard, rules, opts}, acc) when is_list(rules) do
+    normalized = for rule <- rules, do: {wildcard, rule, opts}
+    normalized ++ acc
+  end
+
+  defp normalize_ignore_tuple({wildcard, rule, opts}, acc), do: [{wildcard, rule, opts} | acc]
+
+  defp normalize_ignore_tuple({wildcard, rules}, acc) when is_list(rules) do
+    # @todo update when we add opts to the ignore ruleset
+    normalized = for rule <- rules, do: {wildcard, rule, []}
+    normalized ++ acc
+  end
+
+  defp normalize_ignore_tuple({wildcard, rule}, acc), do: [{wildcard, rule, []} | acc]
+
+  defp default_rules() do
+    for file <- rule_files(),
+        do: Meandro.Util.module_name_from_file_path(file)
+  end
+
+  defp rule_files() do
+    __ENV__.file
+    |> Path.split()
+    |> Enum.slice(0..-4)
+    |> Path.join()
+    |> Path.join(@rules_wildcard)
+    |> Path.wildcard()
+  end
+end

--- a/lib/meandro/meandro_config_parser.ex
+++ b/lib/meandro/meandro_config_parser.ex
@@ -55,13 +55,13 @@ defmodule Meandro.ConfigParser do
   defp get_parsing_style(nil), do: :parallel
   defp get_parsing_style(style), do: style
 
-  defp get_ignores(nil), do: []
-
   @spec get_ignores([
           Path.t()
           | {Path.t(), Meandro.Rule.t() | [Meandro.Rule.t()]}
           | {Path.t(), Meandro.Rule.t() | [Meandro.Rule.t()], list()}
         ]) :: [ignore()]
+  defp get_ignores(nil), do: []
+
   defp get_ignores(ignores) do
     for {wildcard, rule, opts} <- normalize_ignores(ignores),
         file <- expand_wildcard(wildcard),

--- a/lib/meandro/meandro_rule.ex
+++ b/lib/meandro/meandro_rule.ex
@@ -6,7 +6,7 @@ defmodule Meandro.Rule do
 
   defstruct [:module, :file, :line, :text, :rule, :pattern]
 
-  @type t() :: :undefined | module()
+  @type t() :: module()
 
   @type asts() :: [{Path.t(), Macro.t()}]
 
@@ -30,7 +30,7 @@ defmodule Meandro.Rule do
 
   @callback is_ignored?(ignore_pattern(), term()) :: boolean()
 
-  @spec analyze(rule_mod :: module(), asts :: asts(), context :: term()) :: [result()]
+  @spec analyze(rule_mod :: t(), asts :: asts(), context :: term()) :: [result()]
   def analyze(rule_mod, asts, context) do
     for result <- rule_mod.analyze(asts, context),
         do: %Meandro.Rule{result | rule: rule_mod}

--- a/lib/meandro/rules/unused_callbacks.ex
+++ b/lib/meandro/rules/unused_callbacks.ex
@@ -66,7 +66,7 @@ defmodule Meandro.Rule.UnusedCallbacks do
   # We need to keep track of the current module as well, to avoid nested modules messing up
   # our assumptions.
   defp collect_callbacks(
-         {:callback, _, _} = callback,
+         {:callback, _, [{:"::", _, _}]} = callback,
          %{module: module, callbacks: callbacks} = acc
        ) do
     {name, arity, line} = parse(callback)

--- a/lib/meandro/rules/unused_callbacks.ex
+++ b/lib/meandro/rules/unused_callbacks.ex
@@ -66,6 +66,8 @@ defmodule Meandro.Rule.UnusedCallbacks do
   # We need to keep track of the current module as well, to avoid nested modules messing up
   # our assumptions.
   defp collect_callbacks(
+         # Pattern [{:"::", _, _}] defines callbacks in AST. Using that to avoid wrong match
+         # againts a var called "callbacks"
          {:callback, _, [{:"::", _, _}]} = callback,
          %{module: module, callbacks: callbacks} = acc
        ) do

--- a/lib/mix/meandro.ex
+++ b/lib/mix/meandro.ex
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Meandro do
         for %Meandro.Rule{file: file, line: line, module: module, text: text} <- results,
             do: Mix.shell().error("#{file}:#{line} - In module #{module}: #{text}")
 
-        raise "Remove the dead code and try again :)"
+        Mix.shell().info("\nRemove the dead code and try again :)")
     end
   end
 


### PR DESCRIPTION
Closes #13.

**Note:** this PR lays the groundwork for reporting ignored warnings, and is already ignoring the files from the `:ignore` list in the configuration.